### PR TITLE
Fix just installation command in CURATION_GUIDE

### DIFF
--- a/CURATION_GUIDE.md
+++ b/CURATION_GUIDE.md
@@ -32,7 +32,7 @@ These steps only need to be done once.
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Install just (command runner)
-uv tool install rust-just
+uv tool install just
 
 # Verify installations
 uv --version


### PR DESCRIPTION
## Summary
Fixes #2 

Changes the incorrect `uv tool install rust-just` to the correct `uv tool install just`.

## Changes
- Updated CURATION_GUIDE.md line 35
- The package name is `just`, not `rust-just`

## Testing
Verified that `uv tool install just` is the correct command per uv documentation.