### PR TITLE
Update assignments README with real values and flexibility note

### DIFF
--- a/assignments/README.md
+++ b/assignments/README.md
@@ -4,22 +4,42 @@ This directory contains TSV files with class assignments for each curator.
 
 ## Files
 
-- `curator1.tsv`: Classes assigned to curator 1
-- `curator2.tsv`: Classes assigned to curator 2
-- `curator3.tsv`: Classes assigned to curator 3
+- `marcin.tsv`: Classes assigned to Marcin (28 classes)
+- `mark.tsv`: Classes assigned to Mark (32 classes)
+- `sujay.tsv`: Classes assigned to Sujay (32 classes)
+- `curator4.tsv`: Classes assigned to intern 1 (32 classes)
+- `curator5.tsv`: Classes assigned to intern 2 (32 classes)
+- `curator6.tsv`: Classes assigned to intern 3 (31 classes)
+
+**Total**: 147 unique classes from METPO ontology
 
 ## Format
 
 Each file is a ROBOT template with these columns:
-- **ID**: Ontology class ID (e.g., METPO:0000123)
+- **ID**: Ontology class ID (e.g., METPO:1000059)
 - **LABEL**: Human-readable class label
-- **A definition**: Textual definition (to be filled in)
-- **A definition source**: Source citations (PMID, DOI, etc.)
+- **TYPE**: owl:Class
+- **parent class**: Parent class in the hierarchy
+- **description**: Short description of the class
+- **definition source**: Source citations (PMID, DOI, ontology IDs, etc.)
+- **comment**: Additional notes
+- Plus synonym columns for cross-referencing
 
 ## Overlap
 
-Assignments have {{ overlap_percentage }}% overlap for inter-curator agreement assessment.
+Assignments have **20% overlap** for inter-curator agreement assessment.
 This means some classes appear in multiple curator files - this is intentional!
+
+Adjacent curators share overlapping classes to measure consistency in curation decisions.
+
+## Flexibility
+
+**Note**: Class assignments are not fixed! We can move classes between curators if:
+- Someone needs to complete an entire subclass hierarchy
+- Workload needs rebalancing (e.g., reducing Sujay's assignment)
+- Specialized knowledge makes one person better suited
+
+When moving classes, ensure non-overlapping (unique) assignments are redistributed to maintain coverage.
 
 ## Refreshing Assignments
 
@@ -33,9 +53,13 @@ just fetch-assignments
 
 ## Working with Assignments
 
-1. Open your assignment file (e.g., `curator1.tsv`)
+1. Open your assignment file (e.g., `marcin.tsv`)
 2. Fill in definitions and sources for each class
-3. Validate: `just validate-file assignments/curator1.tsv`
+3. Validate: `just validate-file assignments/marcin.tsv`
 4. Commit your changes
 
 See `CURATION_GUIDE.md` for detailed instructions.
+
+## Current Statistics
+
+Run `just assignment-stats` to see current class counts per curator.


### PR DESCRIPTION
## Summary
Fixes #3

Updates the assignments README to replace template placeholders with actual meaningful values and adds documentation about assignment flexibility.

## Changes

### Replaced Templates with Real Values
- Updated curator list with actual names (marcin, mark, sujay) and class counts
- Changed overlap from `{{ overlap_percentage }}%` to actual **20%**
- Added all 6 curator files (3 named + 3 interns)
- Listed actual total: 147 unique classes

### Enhanced Documentation
- Documented full ROBOT template column structure (not just the key ones)
- Added **Flexibility** section explaining classes can be moved between curators
- Noted workload rebalancing options (specifically Sujay's assignment)
- Added current statistics command: `just assignment-stats`
- Updated examples to use real filenames (`marcin.tsv` not `curator1.tsv`)

### Acknowledgments
- Documented that assignments aren't fixed
- Can move classes for hierarchy completion
- Can rebalance workload as needed
- Non-overlapping classes should be redistributed when moving assignments

## Testing
Verified with `just assignment-stats` showing current distribution.